### PR TITLE
BUG-682: Studyinfon hakukentän alla väärän niminen linkki

### DIFF
--- a/Oppija/oph-oppija-v3/css/style.css
+++ b/Oppija/oph-oppija-v3/css/style.css
@@ -2359,10 +2359,6 @@ a.btn.btn-secondary.external:before {
     content: '';
 }
 
-.text-center.search-link a {
-    text-decoration: none;
-}
-
 .input-group-btn:last-child>.btn {
     border-radius: 3px !important;
 }

--- a/Oppija/oph-oppija-v3/header.php
+++ b/Oppija/oph-oppija-v3/header.php
@@ -131,8 +131,8 @@
 
                     <input aria-label="<?php _e('Fill in study programme search word and press enter', 'html5blank') ?>" type="text" tabindex="1" class="search-field" id="search-field-frontpage" data-provide="typeahead" name="search-field" placeholder="<?php _e('Enter eg. qualification, occupation or name of institution', 'html5blank') ?>" value="">
                     
-                    <div class="hidden-xs hidden-sm text-center search-link">
-                        <a href="/app/#!/selailu/aihe"><?php _e('Find education', 'html5blank') ?></a>
+                    <div class="hidden-xs hidden-sm search-link">
+                        <a href="/app/#!/selailu/aihe" class="pull-right"><?php _e('Browse study options', 'html5blank') ?></a>
                     </div>
                     
                     </div>


### PR DESCRIPTION
Korjaa https://jira.oph.ware.fi/jira/browse/BUG-682

Muutokset teemaan:

Hakulinkin käännös, hakulinkin sijoittelu ja alleviivaus. Näyttää nyt suurinpiirtein samalta kun KI-puolella.

Nyt QA ympäristöissä todennettavissa.
